### PR TITLE
Client-Settings button changed and just the whole ClientView based on dev branch

### DIFF
--- a/lang2views-frontend/src/Components/Clients/ClientDeleteButtonClickProcessor.jsx
+++ b/lang2views-frontend/src/Components/Clients/ClientDeleteButtonClickProcessor.jsx
@@ -1,0 +1,17 @@
+function ClientDeleteButtonClickProcessor(props) {
+    if (props === null)
+        throw new Error("props for function ClientDeleteButtonClickProcessor is null");
+
+    if (!props.hasOwnProperty("target"))
+        throw new Error("props does not have property target for function ClientDeleteButtonClickProcessor");
+
+    if (props.target === null)
+        throw new Error("props.target for function ClientDeleteButtonClickProcessor is null");
+
+    if (props.target.id === undefined)
+        throw new Error("props.target does not have property id for function ClientDeleteButtonClickProcessor");
+
+    console.log(props.target.id);
+}
+
+export default ClientDeleteButtonClickProcessor;

--- a/lang2views-frontend/src/Components/Clients/ClientEntriesAndHeader.jsx
+++ b/lang2views-frontend/src/Components/Clients/ClientEntriesAndHeader.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import "./clientEntriesAndHeader.css";
 import clientVideoListProcessor from "./clientVideoListProcessor";
-import clientPlanProcessor from "./clientPlanProcessor";
-import clientVideoSettingsProcessor from "./clientVideoSettingsProcessor";
-import clientDeleteProcessor from "./clientDeleteProcessor";
+import ClientPlanButtonClickProcessor from "./ClientPlanButtonClickProcessor";
+import ClientSettingsButtonClickProcessor from "./ClientSettingsButtonClickProcessor";
+import ClientDeleteButtonClickProcessor from "./ClientDeleteButtonClickProcessor";
 
 function ClientEntriesAndHeader(props) {
     const typeOfClientData = ["client-photo-client-entry-data", "name-client-entry-data", "long-format-client-entry-data", "shorts-client-entry-data", "percentage-done-client-entry-data", "settings-button-client-entry-data", "plan-button-client-entry-data", "video-list-button-client-entry-data", "delete-button-client-entry-data"];
@@ -47,20 +47,20 @@ function ClientEntriesAndHeader(props) {
             clientEntryDataArray.push(partOfAllOfClientEntryDataContainer);
         }
  
-        const settingsButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const settingsButton = <button className="client-entry-action-button btn rounded-circle client-entry-settings-button" onClick={clientVideoSettingsProcessor}>{settingsButtonicon}</button>
+        const settingsButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const settingsButton = <button className="client-entry-action-button btn rounded-circle client-entry-settings-button" onClick={ClientSettingsButtonClickProcessor}>{settingsButtonIcon}</button>
         clientEntryDataArray.push(settingsButton);
 
-        const planButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const planButton = <button className="client-entry-action-button btn rounded-circle client-entry-plan-button" onClick={clientPlanProcessor}>{planButtonicon}</button>
+        const planButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const planButton = <button className="client-entry-action-button btn rounded-circle client-entry-plan-button" onClick={ClientPlanButtonClickProcessor}>{planButtonIcon}</button>
         clientEntryDataArray.push(planButton);
 
-        const videoListButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const videoListButton = <button className="client-entry-action-button btn rounded-circle client-entry-video-list-button" onClick={clientVideoListProcessor}>{videoListButtonicon}</button>
+        const videoListButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const videoListButton = <button className="client-entry-action-button btn rounded-circle client-entry-video-list-button" onClick={clientVideoListProcessor}>{videoListButtonIcon}</button>
         clientEntryDataArray.push(videoListButton);
 
-        const deleteButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const deleteButton = <button className="client-entry-action-button btn rounded-circle client-entry-delete-button" onClick={clientDeleteProcessor}>{deleteButtonicon}</button>
+        const deleteButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const deleteButton = <button className="client-entry-action-button btn rounded-circle client-entry-delete-button" onClick={ClientDeleteButtonClickProcessor}>{deleteButtonIcon}</button>
         clientEntryDataArray.push(deleteButton);
 
         const clientEntryContainer = <div className="client-entry border border-secondary rounded">{clientEntryDataArray}</div>;

--- a/lang2views-frontend/src/Components/Clients/ClientPlanButtonClickProcessor.jsx
+++ b/lang2views-frontend/src/Components/Clients/ClientPlanButtonClickProcessor.jsx
@@ -1,0 +1,17 @@
+function ClientPlanButtonClickProcessor(props) {
+    if (props === null)
+        throw new Error("props for function ClientPlanButtonClickProcessor is null");
+
+    if (!props.hasOwnProperty("target"))
+        throw new Error("props does not have property target for function ClientPlanButtonClickProcessor");
+
+    if (props.target === null)
+        throw new Error("props.target for function ClientPlanButtonClickProcessor is null");
+
+    if (props.target.id === undefined)
+        throw new Error("props.target does not have property id for function ClientPlanButtonClickProcessor");
+
+    console.log(props.target.id);
+}
+
+export default ClientPlanButtonClickProcessor;

--- a/lang2views-frontend/src/Components/Clients/ClientSettingsButtonClickProcessor.jsx
+++ b/lang2views-frontend/src/Components/Clients/ClientSettingsButtonClickProcessor.jsx
@@ -1,0 +1,16 @@
+import { createRoot } from "react-dom/client";
+import ClientSettings from "../client-settings/ClientSettings";
+import React from "react";
+
+function ClientSettingsButtonClickProcessor(props) {
+    if (props === null)
+        throw new Error("props for function ClientSettingsButtonClickProcessor is null");
+
+    const popupAndCloseAreaContainer = document.querySelector(".popup-and-close-area-container");
+
+    const clientsViewHook = createRoot(popupAndCloseAreaContainer);
+    
+    clientsViewHook.render(<ClientSettings channelName={props.channelName} />);
+}
+
+export default ClientSettingsButtonClickProcessor;

--- a/lang2views-frontend/src/Components/Clients/ClientsView.jsx
+++ b/lang2views-frontend/src/Components/Clients/ClientsView.jsx
@@ -70,6 +70,7 @@ function ClientsView(props) {
             clientEntries={clientEntries}
           />
         </div>
+        <div className='popup-and-close-area-container'></div>
       </div>
   );
 }

--- a/lang2views-frontend/src/Components/Sample-creation/SampleCreationEntriesAndHeader.jsx
+++ b/lang2views-frontend/src/Components/Sample-creation/SampleCreationEntriesAndHeader.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import "./sampleCreationEntriesAndHeader.css";
 import clientVideoListProcessor from "../Clients/clientVideoListProcessor";
-import clientPlanProcessor from "../Clients/clientPlanProcessor";
-import clientVideoSettingsProcessor from "../Clients/clientVideoSettingsProcessor";
-import clientDeleteProcessor from "../Clients/clientDeleteProcessor";
+import ClientPlanButtonClickProcessor from "../Clients/ClientPlanButtonClickProcessor";
+import ClientSettingsButtonClickProcessor from "../Clients/ClientSettingsButtonClickProcessor";
+import ClientDeleteButtonClickProcessor from "../Clients/ClientDeleteButtonClickProcessor";
 
 function SampleCreationEntriesAndHeader(props) {
     const typeOfClientData = ["client-photo-client-entry-data", "name-client-entry-data", "long-format-client-entry-data", "shorts-client-entry-data", "percentage-done-client-entry-data", "settings-button-client-entry-data", "plan-button-client-entry-data", "video-list-button-client-entry-data", "delete-button-client-entry-data"];
@@ -47,20 +47,20 @@ function SampleCreationEntriesAndHeader(props) {
             clientEntryDataArray.push(partOfAllOfClientEntryDataContainer);
         }
  
-        const settingsButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const settingsButton = <button className="client-entry-action-button btn rounded-circle client-entry-settings-button" onClick={clientVideoSettingsProcessor}>{settingsButtonicon}</button>
+        const settingsButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const settingsButton = <button className="client-entry-action-button btn rounded-circle client-entry-settings-button" onClick={ClientSettingsButtonClickProcessor}>{settingsButtonIcon}</button>
         clientEntryDataArray.push(settingsButton);
 
-        const planButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const planButton = <button className="client-entry-action-button btn rounded-circle client-entry-plan-button" onClick={clientPlanProcessor}>{planButtonicon}</button>
+        const planButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const planButton = <button className="client-entry-action-button btn rounded-circle client-entry-plan-button" onClick={ClientPlanButtonClickProcessor}>{planButtonIcon}</button>
         clientEntryDataArray.push(planButton);
 
-        const videoListButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const videoListButton = <button className="client-entry-action-button btn rounded-circle client-entry-video-list-button" onClick={clientVideoListProcessor}>{videoListButtonicon}</button>
+        const videoListButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const videoListButton = <button className="client-entry-action-button btn rounded-circle client-entry-video-list-button" onClick={clientVideoListProcessor}>{videoListButtonIcon}</button>
         clientEntryDataArray.push(videoListButton);
 
-        const deleteButtonicon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
-        const deleteButton = <button className="client-entry-action-button btn rounded-circle client-entry-delete-button" onClick={clientDeleteProcessor}>{deleteButtonicon}</button>
+        const deleteButtonIcon = <img className="client-entry-action-icon rounded-circle" id={`client-${row + 1}`} src="src/Images/brown.png"></img>;
+        const deleteButton = <button className="client-entry-action-button btn rounded-circle client-entry-delete-button" onClick={ClientDeleteButtonClickProcessor}>{deleteButtonIcon}</button>
         clientEntryDataArray.push(deleteButton);
 
         const clientEntryContainer = <div className="client-entry border border-secondary rounded">{clientEntryDataArray}</div>;

--- a/lang2views-frontend/src/Components/Utilities/popup.css
+++ b/lang2views-frontend/src/Components/Utilities/popup.css
@@ -1,0 +1,3 @@
+.popup-menus-step-area {
+    margin-top: 5em;
+}

--- a/lang2views-frontend/src/Components/client-settings/ClientSettings.jsx
+++ b/lang2views-frontend/src/Components/client-settings/ClientSettings.jsx
@@ -1,0 +1,27 @@
+import "./clientSettings.css";
+import React, { useState } from "react";
+import CloseClientSettingsPopup from "./CloseClientSettingsPopup";
+import ClientSettingsPlanButtonClickProcessor from "./buttons/ClientSettingsPlanButtonClickProcessor";
+import ClientSettingsTranscriptionButtonClickProcessor from "./buttons/ClientSettingsTranscriptionButtonClickProcessor";
+import Plan from "./buttons/Plan";
+
+function ClientSettings(props) {
+  if (props === null) {
+    throw new Error("No props for ClientSettings");
+  }
+
+  return (
+    <>
+      <div className="client-settings-close-area" onClick={CloseClientSettingsPopup}></div>
+      <div className="client-settings-popup d-flex flex-direction-column align-items-start">
+        <button onClick={ClientSettingsPlanButtonClickProcessor}>Plan</button>
+        <button onClick={ClientSettingsTranscriptionButtonClickProcessor}>Transcription</button>
+        <div className="popup-menus-step-area">
+          <Plan channelName={props.channelName}/>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default ClientSettings;

--- a/lang2views-frontend/src/Components/client-settings/CloseClientSettingsPopup.jsx
+++ b/lang2views-frontend/src/Components/client-settings/CloseClientSettingsPopup.jsx
@@ -1,0 +1,10 @@
+import { createRoot } from "react-dom/client";
+
+function CloseClientSettingsPopup() {
+    const popupAndCloseContainer = document.querySelector(".popup-and-close-area-container");
+    const popupAndCloseContainerRoot = createRoot(popupAndCloseContainer);
+
+    popupAndCloseContainerRoot.render(null);
+}
+
+export default CloseClientSettingsPopup;

--- a/lang2views-frontend/src/Components/client-settings/buttons/ClientSettingsPlanButtonClickProcessor.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/ClientSettingsPlanButtonClickProcessor.jsx
@@ -1,0 +1,12 @@
+import { createRoot } from "react-dom/client";
+import Plan from "./Plan";
+import "../../Utilities/popup.css";
+
+function ClientSettingsPlanButtonClickProcessor() {
+    const popupsMenusStepAArea = document.querySelector(".popup-menus-step-area");
+    const clientSettingsPlanButtonRoot = createRoot(popupsMenusStepAArea);
+
+    clientSettingsPlanButtonRoot.render(<Plan channelName="Alex" />);
+}
+
+export default ClientSettingsPlanButtonClickProcessor;

--- a/lang2views-frontend/src/Components/client-settings/buttons/ClientSettingsTranscriptionButtonClickProcessor.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/ClientSettingsTranscriptionButtonClickProcessor.jsx
@@ -1,0 +1,12 @@
+import { createRoot } from "react-dom/client";
+import "../../Utilities/popup.css";
+import Transcription from "./Transcription";
+
+function ClientSettingsTranscriptionButtonClickProcessor() {
+    const popupsMenusStepAArea = document.querySelector(".popup-menus-step-area");
+    const clientSettingsPlanButtonRoot = createRoot(popupsMenusStepAArea);
+
+    clientSettingsPlanButtonRoot.render(<Transcription channelName="Alex" />);
+}
+
+export default ClientSettingsTranscriptionButtonClickProcessor;

--- a/lang2views-frontend/src/Components/client-settings/buttons/EstimatedPrice.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/EstimatedPrice.jsx
@@ -1,0 +1,7 @@
+import "../clientSettings.css";
+
+function EstimatedPriceInput() {
+    return <div className="text-input-container"><h2>Estimated Price</h2><label htmlFor="estimated-price-input"></label><input className="form-control form-control-lg" id="estimated-price-input" readOnly=""></input></div>
+}
+
+export default EstimatedPriceInput;

--- a/lang2views-frontend/src/Components/client-settings/buttons/MonthlyPlanTogglesWithLabel.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/MonthlyPlanTogglesWithLabel.jsx
@@ -1,0 +1,11 @@
+import "../clientSettings.css";
+
+function MonthlyPlanTogglesWithLabel() {
+    return <div id="use-monthly-plan-container"><h2>Monthly Plan</h2><Toggles /></div>;
+}
+
+function Toggles() {
+    return <div><button>Disabled</button><button>Enabled</button></div>;
+}
+
+export default MonthlyPlanTogglesWithLabel;

--- a/lang2views-frontend/src/Components/client-settings/buttons/NumLongFormatInput.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/NumLongFormatInput.jsx
@@ -1,0 +1,7 @@
+import "../clientSettings.css";
+
+function NumLongFormatInput() {
+    return <div className="text-input-container"><h2>Long format</h2><label htmlFor="num-long-format-input"></label><input className="form-control form-control-lg" id="num-long-format-input"></input></div>
+}
+
+export default NumLongFormatInput;

--- a/lang2views-frontend/src/Components/client-settings/buttons/NumShortsInput.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/NumShortsInput.jsx
@@ -1,0 +1,7 @@
+import "../clientSettings.css";
+
+function NumShortsInput() {
+    return <div className="text-input-container"><h2>Shorts</h2><label htmlFor="num-shorts-input"></label><input className="form-control form-control-lg" id="num-shorts-input"></input></div>
+}
+
+export default NumShortsInput;

--- a/lang2views-frontend/src/Components/client-settings/buttons/Plan.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/Plan.jsx
@@ -1,0 +1,18 @@
+import EstimatedPriceInput from "./EstimatedPrice";
+import MonthlyPlanTogglesWithLabel from "./MonthlyPlanTogglesWithLabel";
+import NumLongFormatInput from "./NumLongFormatInput";
+import NumShortsInput from "./NumShortsInput";
+import ProcessingAmountSlider from "./ProcessingAmountSlider";
+import "../clientSettings.css";
+
+function Plan(props) {
+    if (props === null)
+        return new Error("props for Plan in client settings is null");
+
+    if (props.channelName === null)
+        return new Error("No channelName for plan section of clientSettings");
+
+    return <div><p>{props.channelName}</p><br /><MonthlyPlanTogglesWithLabel /><div id="num-long-formats-and-shorts-container"><NumLongFormatInput /><NumShortsInput /></div><ProcessingAmountSlider /><EstimatedPriceInput /></div>;
+}
+
+export default Plan;

--- a/lang2views-frontend/src/Components/client-settings/buttons/ProcessingAmountSlider.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/ProcessingAmountSlider.jsx
@@ -1,0 +1,7 @@
+import "../clientSettings.css";
+
+function ProcessingAmountSlider() {
+    return <div id="processing-amount-slider-container"><h2>Level of Post-Production</h2><input aria-label="Level of Post-Production" type="range" className="py-0" min={1} max={3}></input></div>
+}
+
+export default ProcessingAmountSlider;

--- a/lang2views-frontend/src/Components/client-settings/buttons/Transcription.jsx
+++ b/lang2views-frontend/src/Components/client-settings/buttons/Transcription.jsx
@@ -1,0 +1,13 @@
+import "../clientSettings.css";
+
+function Transcription(props) {
+    if (props === null)
+        return new Error("props for Plan in client settings is null");
+
+    if (props.channelName === null)
+        return new Error("No channelName for transcription section of clientSettings");
+
+    return <div><p>{props.channelName}</p><br /></div>;
+}
+
+export default Transcription;

--- a/lang2views-frontend/src/Components/client-settings/clientSettings.css
+++ b/lang2views-frontend/src/Components/client-settings/clientSettings.css
@@ -1,0 +1,51 @@
+.client-settings-popup {
+    display: flex;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #FFF;
+    margin-left: 50%;
+}
+
+.client-settings-close-area {
+    display: flex;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 45%;
+    height: 100%;
+    background-color: transparent;
+    margin-left: 5%;
+}
+
+#use-monthly-plan-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: 5%;
+}
+
+#toggles-container {
+    display: flex;
+    flex-direction: row;
+}
+
+#num-long-formats-and-shorts-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.text-input-container {
+    width: 40%;
+}
+
+#processing-amount-slider-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}


### PR DESCRIPTION
client-settings-button on click adds a modal. That modal contains all of the client-settings steps (Monthly plan, Transcription etc.) and they are rendered when the step link, button right now, is clicked. They get rendered into a blank space on the modal.