### PR TITLE
Add Sample page.

### DIFF
--- a/lang2views-frontend/src/Components/Sample-creation/AddSample.jsx
+++ b/lang2views-frontend/src/Components/Sample-creation/AddSample.jsx
@@ -1,0 +1,41 @@
+import { createRoot } from "react-dom/client";
+import { SampleAndClientCreationViews } from "../../Pages/clientAndSampleCreationViews";
+
+function saveSampleButtonClick() {
+    const sampleuUrlInput = document.querySelector("#sampleUrl");
+
+    console.log(sampleuUrlInput.value + '\n');
+
+    const root = document.querySelector("#root");
+    const addSampleHook = createRoot(root);
+
+    addSampleHook.render(<SampleAndClientCreationViews />);
+}
+
+
+function SaveSample() {
+  return (
+    <div className="d-flex flex-row justify-content-center">
+      <button className="btn btn-primary" onClick={saveSampleButtonClick}>
+        Add Sample
+      </button>
+    </div>
+  );
+}
+
+function AddSample() {
+  return (
+    <div className="d-flex flex-row justify-content-center mt-5">
+      <div>
+        <div className="mb-4">
+          <h2>Sample url</h2>
+          <input className="form-control" id="sampleUrl" />
+        </div>
+        <SaveSample />
+      </div>
+    </div>
+  );
+}
+
+
+export default AddSample

--- a/lang2views-frontend/src/Components/Sample-creation/AddSampleButton.jsx
+++ b/lang2views-frontend/src/Components/Sample-creation/AddSampleButton.jsx
@@ -1,7 +1,17 @@
 import React from "react";
+import { createRoot } from "react-dom/client";
+import AddSample from "./AddSample";
+
+function addSampleButtonClick() {
+    const root = document.querySelector("#root");
+    const addSampleHook = createRoot(root);
+
+    window.history.replaceState({}, "addSample", "/addSample");
+    addSampleHook.render(<AddSample />);
+}
 
 function AddSampleButton() {
-    return React.createElement("input", {value: "+ Add sample", type: "button", className: "btn btn-primary", id: "add-sample-button"});
+    return <button className="btn btn-primary" id="add-sample-button" onClick={addSampleButtonClick}>+ Add Sample</button>
 }
 
 export default AddSampleButton;

--- a/lang2views-frontend/src/Components/Sidebar/ClientsViewButton.jsx
+++ b/lang2views-frontend/src/Components/Sidebar/ClientsViewButton.jsx
@@ -26,20 +26,39 @@ function renderClientsView() {
   viewContainerHook.render(<ClientsView currentUser={"Alexander"} />);
 }
 
-function ClientsViewButton() {
-  const accountPicture = (
-        <img id="clients-view-button-icon" src="src/Images/clientActive.png"></img>
-  );
+function ClientsViewButton(props) {
+  
+    if (props.default === "client") {
+        const accountPicture = (
+            <img id="clients-view-button-icon" src="src/Images/clientActive.png"></img>
+        );
 
-  return (
-    <button
-      onClick={renderClientsView}
-      className="btn buttonActive"
-      id="clients-view-button"
-    >
-      {accountPicture}
-    </button>
-  );
+        return (
+            <button
+                onClick={renderClientsView}
+                className="btn buttonActive"
+                id="clients-view-button"
+            >
+                {accountPicture}
+            </button>
+        );
+    }
+    else {
+        const accountPicture = (
+            <img id="clients-view-button-icon" src="src/Images/client.png"></img>
+        );
+
+        return (
+            <button
+                onClick={renderClientsView}
+                className="btn buttonInactive"
+                id="clients-view-button"
+            >
+                {accountPicture}
+            </button>
+        );
+
+    }
 }
 
 export default ClientsViewButton;

--- a/lang2views-frontend/src/Components/Sidebar/SampleCreationViewButton.jsx
+++ b/lang2views-frontend/src/Components/Sidebar/SampleCreationViewButton.jsx
@@ -26,10 +26,16 @@ function renderSampleCreationView() {
     viewContainerHook.render(<SampleCreationView currentUser={"Alexander"}/>);
 }
 
-function SampleCreationViewButton() {
-    const sampleCreationViewLogo = <img id="sample-creation-view-button-icon" src="src/Images/sample.png"></img>;
+function SampleCreationViewButton(props) {
 
-    return <button onClick={renderSampleCreationView} className="btn buttonInactive" id="sample-creation-view-button">{sampleCreationViewLogo}</button>;
+    if (props.default === "client") {
+        const sampleCreationViewLogo = <img id="sample-creation-view-button-icon" src="src/Images/sample.png"></img>;
+        return <button onClick={renderSampleCreationView} className="btn buttonInactive" id="sample-creation-view-button">{sampleCreationViewLogo}</button>;
+    }
+    else {
+        const sampleCreationViewLogo = <img id="sample-creation-view-button-icon" src="src/Images/sampleActive.png"></img>;
+        return <button onClick={renderSampleCreationView} className="btn buttonActive" id="sample-creation-view-button">{sampleCreationViewLogo}</button>;
+    }
 }
 
 export default SampleCreationViewButton;

--- a/lang2views-frontend/src/Components/Sidebar/Sidebar.jsx
+++ b/lang2views-frontend/src/Components/Sidebar/Sidebar.jsx
@@ -4,12 +4,12 @@ import LogoutButton from "./LogoutButton";
 import SampleCreationViewButton from "./SampleCreationViewButton";
 import './sidebar.css';
 
-function Sidebar() {
+function Sidebar(props) {
   return (
     <div id="sidebar" className="d-flex flex-column">
       <AppLogo />
-      <ClientsViewButton />
-      <SampleCreationViewButton />
+          <ClientsViewButton default={props.default} />
+          <SampleCreationViewButton default={props.default} />
       <LogoutButton />
     </div>
   );

--- a/lang2views-frontend/src/Pages/clientAndSampleCreationViews.jsx
+++ b/lang2views-frontend/src/Pages/clientAndSampleCreationViews.jsx
@@ -1,17 +1,32 @@
 import ClientsView from "../Components/Clients/ClientsView";
+import SampleView from "../Components/Sample-creation/SampleCreationView";
 import Sidebar from "../Components/Sidebar/Sidebar";
 import "../Components/Utilities/viewContainer.css";
 import "../Components/Utilities/main.css";
 
+//Renders the Client Page.
 function ClientAndSampleCreationViews() {
   return (
     <div className="d-flex flex-row main">
-      <Sidebar />
+      <Sidebar default="client"/>
       <div id="view-container">
         <ClientsView currentUser={"Alexander"}/>
       </div>
     </div>
   );
+}
+
+//Renders the Sample Page.
+export function SampleAndClientCreationViews() {
+
+    return (
+        <div className="d-flex flex-row main">
+            <Sidebar default="sample"/>
+            <div id="view-container">
+                <SampleView currentUser={"Alexander"} />
+            </div>
+        </div>
+    );
 }
 
 export default ClientAndSampleCreationViews;


### PR DESCRIPTION
Add sample page.
Changes to sidebar and clientAndSampleCreationViews to allow user to return directly to the sample page from the add sample page after clicking the add sample button.